### PR TITLE
JSON deps fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ function ngConstantPlugin(opts) {
             // Create the module string
             var result = _.template(template, {
                 moduleName: options.name || data.name,
-                deps:       options.deps || data.deps || [],
+                deps:       data.deps || options.deps,
                 constants:  getConstants(data, options)
             });
 


### PR DESCRIPTION
The behavior should be "Check deps field in the json file, if none provided then use the one from the options (which is either rhe one provided through options or [] because of the initial merge with defaults)"

A the moment it ignores the JSON deps because options.deps is always there (from merge with defaults)
