### PR TITLE
fixed check for dependencies in constant template

### DIFF
--- a/tpls/constant.tpl.ejs
+++ b/tpls/constant.tpl.ejs
@@ -1,4 +1,4 @@
-angular.module("<%- moduleName %>"<% if (deps) { %>, <%= JSON.stringify(deps) %><% } %>)
+angular.module("<%- moduleName %>"<% if (deps[0] != null) { %>, <%= JSON.stringify(deps) %><% } %>)
 <% constants.forEach(function(constant) { %>
 .constant("<%- constant.name %>", <%= constant.value %>)
 <% }) %>


### PR DESCRIPTION
Firstly, thank you for this plugin =)
I found strange behavior when "deps" option is not defined in json file.
Example:

```
{
    "name": "exmpl",
    "constants": {
            "protocol": "http",
            "hostname": "localhost",
            "port": "80"
}
}
```

compiles to

```
angular.module("exmpl", [])

.constant(  "protocol": "http")
.constant(  "hostname": "localhost")
.constant("port": "80")
;
```

Using this code, i get same error http://stackoverflow.com/questions/16006313/unknown-provider-resourceprovider-resource-with-angularjs
I think, if "deps" option is not defined, angular module should not include empty dependencies array.

```
angular.module("exmpl")

.constant(  "protocol": "http")
.constant(  "hostname": "localhost")
.constant("port": "80")
;
```
