### PR TITLE
feat: add options.dest

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ Overrides: `json.name`
 The module name.
 This property will override any `name` property defined in the input `json` file.
 
+#### options.dest
+
+Type: `string`  
+Default: `undefined`
+_optional_
+
+The path where the generated constant module should be saved.
+
 #### options.constants
 
 Type: `Object | string`  

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ function ngConstantPlugin(opts) {
             if (!options.wrap) { options.wrap = data.wrap; }
             result = wrap(result, options);
 
-            file.path = gutil.replaceExtension(file.path, '.js');
+            file.path = getFilePath(file.path, options);
             file.contents = new Buffer(result);
             _this.push(file);
         } catch (err) {
@@ -80,6 +80,14 @@ function getConstants(data, options) {
     });
 
     return constants;
+}
+
+function getFilePath(filePath, options) {
+    if (!options.dest) {
+        return gutil.replaceExtension(filePath, '.js');
+    }
+
+    return path.join(path.dirname(filePath), options.dest);
 }
 
 function pluginError(msg) {
@@ -111,6 +119,7 @@ function stringify(value, space) {
 
 _.extend(ngConstantPlugin, {
     getConstants: getConstants,
+    getFilePath: getFilePath,
     wrap: wrap
 });
 

--- a/spec/gulpNgConstantSpec.js
+++ b/spec/gulpNgConstantSpec.js
@@ -36,3 +36,13 @@ describe('ngConstant.getConstants', function () {
         expect(result[0].value).toEqual('{\n "foo": "bar"\n}');
     });
 });
+
+describe('ngConstant.getFilePath', function() {
+    it('returns the file path from the src plugin when option dest is undefined', function() {
+        expect(ngConstant.getFilePath('/foo/bar/config.json', {})).toBe('/foo/bar/config.js');
+    });
+
+    it('returns the file path defined by the dest option', function() {
+        expect(ngConstant.getFilePath('/foo/bar/foo.js', { dest: 'foo.js' })).toBe('/foo/bar/foo.js');
+    });
+});


### PR DESCRIPTION
Add a dest option to generate the constant file to a specific path or to change the default file name

This options is available in the grunt plugin. I plan to migrate from grunt to gulp and this option will be nice :)
Our json config files are suffixed by the target environment, in the same folder. At the moment, a file placed in /config/config_dev.json can not be generated to /src/app/config.js.
