### PR TITLE
Vinyl adapter option

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,8 +25,13 @@ function ngConstantPlugin(opts) {
 
     var options = _.merge({}, defaults, opts);
     var template = options.template || readFile(options.templatePath);
+    var stream = through.obj(objectStream);
 
-    return through.obj(objectStream);
+    if (options.noFile) {
+      stream.end(new gutil.File({ path: 'constants.json' }));
+    }
+
+    return stream;
 
     function objectStream(file, enc, cb) {
         /* jshint validthis: true */


### PR DESCRIPTION
It seems to me that this gulp plugin should be completely usable without a physical file to source the constants from, because you can pass an object via the `constants` option. But the current setup doesn't really allow it.

I've added a `noFile` option that allows the plugin to act as a vinyl adapter, meaning it can be used in place of `gulp.src`. For example:

```javascript
var gulp = require('gulp');
var ngConstant = require('gulp-ng-constant');
var uglify = require('gulp-uglify');
var constants = { hello: 'world' };

gulp.task('config', function () {
  return ngConstant({name: 'my.module.config', constants: constants, noFile: true})
    .pipe(uglify())  
    .pipe(gulp.dest('dist'));
});
```

The default outputted filename will be `constants.js`.