### PR TITLE
Quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Based of <a href="https://github.com/werk85/grunt-ng-constant">grunt-ng-constant
   * [deps](#optionsdeps)
   * [wrap](#optionswrap)
   * [space](#optionsspace)
+  * [quote](#optionsquote)
   * [template](#optionstemplate)
   * [templatePath](#optionstemplatepath)
 1. [Examples](#examples)
@@ -193,6 +194,14 @@ Default: `'\t'`
 _optional_
 
 A string that defines how the JSON.stringify method will prettify your code.
+
+#### options.quote
+
+Type: `string`  
+Default: `'\"'`  
+_optional_
+
+A string that defines if the constant file should be built using single or double quotes. Use it if you're using single quotes in your code (removes JSHint warnings for the constant file using double quotes).
 
 #### options.template
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ var defaultWrapper, amdWrapper, commonjsWrapper;
 
 var defaults = {
     space: '\t',
-    quote: '\"', // Double quotes being: \'
+    quote: '\"', // Single quotes being: \'
     deps: null,
     stream: false,
     wrap: false,

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ var defaultWrapper, amdWrapper, commonjsWrapper;
 
 var defaults = {
     space: '\t',
+    quote: '\"', // Double quotes being: \'
     deps: null,
     stream: false,
     wrap: false,
@@ -51,7 +52,8 @@ function ngConstantPlugin(opts) {
             var result = _.template(template, {
                 moduleName: getModuleName(data, options, file),
                 deps:       getModuleDeps(data, options),
-                constants:  getConstants(data, options)
+                constants:  getConstants(data, options),
+                quote: getModuleQuote(data, options)
             });
 
             // Handle wrapping
@@ -104,6 +106,15 @@ function getConstants(data, options) {
     });
 
     return constants;
+}
+
+function getModuleQuote(data, options) {
+    var quote = options.quote || data.quote;
+    if (!quote) {
+        quote = '\"';
+    }
+
+    return quote;
 }
 
 function getFilePath(filePath, options) {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,9 @@
     "test": "node_modules/jasmine-node/bin/jasmine-node spec/gulpNgConstantSpec.js"
   },
   "dependencies": {
-    "lodash": "^2.4.1",
     "gulp-util": "^2.2.14",
+    "html-entities": "^1.1.2",
+    "lodash": "^2.4.1",
     "through2": "^0.4.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "gulp-ng-constant",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Gulp plugin for dynamic generation of angular constant modules.",
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git://github.com/guzart/gulp-ng-constant.git"
+    "url": "git://github.com/rafaelfragosom/gulp-ng-constant.git"
   },
   "keywords": [
     "gulp",
@@ -13,12 +13,12 @@
     "constant",
     "gulpplugin"
   ],
-  "author": "Arturo Guzman",
+  "author": "Rafael Fragoso",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/guzart/gulp-ng-constant/issues"
+    "url": "https://github.com/rafaelfragosom/gulp-ng-constant/issues"
   },
-  "homepage": "https://github.com/guzart/gulp-ng-constant",
+  "homepage": "https://github.com/rafaelfragosom/gulp-ng-constant",
   "scripts": {
     "test": "node_modules/jasmine-node/bin/jasmine-node spec/gulpNgConstantSpec.js"
   },

--- a/tpls/amd-wrapper.tpl.ejs
+++ b/tpls/amd-wrapper.tpl.ejs
@@ -1,3 +1,3 @@
-define(["require", "exports"], function(require, exports) {
+define([<%- quote %>require<%- quote %>, <%- quote %>exports<%- quote %>], function(require, exports) {
   return <%= __ngModule %>
 });

--- a/tpls/constant.tpl.ejs
+++ b/tpls/constant.tpl.ejs
@@ -1,5 +1,5 @@
-angular.module("<%- moduleName %>"<% if (deps) { %>, <%= JSON.stringify(deps) %><% } %>)
+angular.module(<%- quote %><%- moduleName %><%- quote %><% if (deps) { %>, <%= JSON.stringify(deps) %><% } %>)
 <% constants.forEach(function(constant) { %>
-.constant("<%- constant.name %>", <%= constant.value %>)
+.constant(<%- quote %><%- constant.name %><%- quote %>, <%= constant.value %>)
 <% }) %>
 ;


### PR DESCRIPTION
I've been using this Gulp plugin for a week and my code is using single quotes, so I keep getting this warning from JSHint that the constants file is using double quotes and it doesn't match the code style.

I added another option to the plugin to able developers to set a quote style when generating the file. 

--------------------------------

I wrote 2 more tests and a function to decode HTML string because the `toString()` method was escaping the quotes and making the tests fail. Using this npm plugin [html-entities](https://www.npmjs.com/package/html-entities).

PS: Not sure if I could update the version of the plugin (I didn't).