### PR TITLE
Allow constants to be defined in .yaml in addition to .json files

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var fs = require('fs');
+var yaml = require('js-yaml');
 var path = require('path');
 var gutil = require('gulp-util');
 var through = require('through2');
@@ -45,7 +46,7 @@ function ngConstantPlugin(opts) {
         }
 
         try {
-            var data = file.isNull() ? {} : JSON.parse(file.contents);
+            var data = file.isNull() ? {} : yaml.safeLoad(file.contents);
 
             // Create the module string
             var result = _.template(template, {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/guzart/gulp-ng-constant",
   "scripts": {
     "test": "node_modules/jasmine-node/bin/jasmine-node spec/gulpNgConstantSpec.js"
-  },inde
+  },
   "dependencies": {
     "gulp-util": "^2.2.14",
     "js-yaml": "^3.2.7",

--- a/package.json
+++ b/package.json
@@ -21,10 +21,11 @@
   "homepage": "https://github.com/guzart/gulp-ng-constant",
   "scripts": {
     "test": "node_modules/jasmine-node/bin/jasmine-node spec/gulpNgConstantSpec.js"
-  },
+  },inde
   "dependencies": {
-    "lodash": "^2.4.1",
     "gulp-util": "^2.2.14",
+    "js-yaml": "^3.2.7",
+    "lodash": "^2.4.1",
     "through2": "^0.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
I prefer to use YAML files for configuration over JSON files.

Instead of parsing the file.contents with JSON.parse, I changed it to use the js-yaml node module to do the parsing.

This will allow the file to be defined in YAML format or JSON format, since JSON is valid YAML.

Thoughts?