### PR TITLE
Added option for using a namespace in the standard runner

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,9 @@ function ngConstantPlugin(opts) {
 
     try {
       var data = file.isNull() ? {} : yaml.safeLoad(file.contents);
-
+      
+      data = options.namespace ? data[options.namespace] : data;
+      
       // Create the module string
       var result = _.template(template)({
         moduleName: getModuleName(data, options, file),


### PR DESCRIPTION
It's weird that in order to handle multiple environments we can't use the standard gulp.src syntax, so this just adds "namespace" as an optional argument.