### PR TITLE
Override name even if stream is true

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function ngConstantPlugin(opts) {
   var stream = through.obj(objectStream);
 
   if (options.stream) {
-    stream.end(new gutil.File({ path: 'ngConstants.json' }));
+    stream.end(new gutil.File({ path: (opts.name || 'ngConstants') + '.json' }));
   }
 
   return stream;


### PR DESCRIPTION
It seems to take the base name of the string passed into path in the `gutil.File` constructor, so allow overwriting with option